### PR TITLE
feat: Hysteresis Updates and Enabling Fusaka EIPs

### DIFF
--- a/meta/BRIP-0001.md
+++ b/meta/BRIP-0001.md
@@ -2,7 +2,7 @@
 mip: 0001
 title: Execution Layer Forked Clients
 author: calbera, rezbera
-status: Accepted
+status: Final
 created: 2025-06-02
 type: Core
 ---

--- a/meta/BRIP-0002.md
+++ b/meta/BRIP-0002.md
@@ -2,7 +2,7 @@
 mip: 0002
 title: Gas Fee Modifications
 author: rezbera
-status: Accepted
+status: Final
 created: 2025-05-29
 type: Core
 ---

--- a/meta/BRIP-0003.md
+++ b/meta/BRIP-0003.md
@@ -2,7 +2,7 @@
 mip: 0003
 title: Stable Block Time
 author: aBear, fridrik01
-status: Accepted
+status: Final
 created: 2025-06-16
 type: Core
 ---

--- a/meta/BRIP-0004.md
+++ b/meta/BRIP-0004.md
@@ -2,7 +2,7 @@
 mip: 0004
 title: Enshrined Proof of Liquidity Reward Distribution
 author: rezbera, calbera
-status: Accepted
+status: Final
 created: 2025-06-19
 type: Core
 requires: BRIP-0001

--- a/meta/BRIP-0007.md
+++ b/meta/BRIP-0007.md
@@ -2,7 +2,7 @@
 brip: 0007
 title: Berachain Preconfirmations
 author: rezbera, calbera, aBear, fridrik01, grizzlybera, tio
-status: Draft
+status: Review
 created: 2025-10-22
 type: Core
 ---

--- a/meta/BRIP-0008.md
+++ b/meta/BRIP-0008.md
@@ -2,7 +2,7 @@
 brip: 0008
 title: Validator Effective Balance Hysteresis Constant Update
 author: P-OPS Team
-status: Draft
+status: Accepted
 created: 2026-03-30
 type: Core
 ---

--- a/meta/BRIP-0008.md
+++ b/meta/BRIP-0008.md
@@ -40,9 +40,9 @@ These constants are defined in the [mainnet.go](https://github.com/berachain/bea
  
 The upward and downward thresholds are derived from the constants as follows:
  
-- **Downward threshold** = `effectiveBalanceIncrement` - (`effectiveBalanceIncrement` * `hysteresisDownwardMultiplier` / `hysteresisQuotient`)
-- **Upward threshold** = `effectiveBalanceIncrement` + (`effectiveBalanceIncrement` * `hysteresisUpwardMultiplier` / `hysteresisQuotient`)
- 
+- **Downward threshold** = (`effectiveBalanceIncrement` / `hysteresisQuotient`) * `hysteresisDownwardMultiplier`
+- **Upward threshold** = (`effectiveBalanceIncrement` / `hysteresisQuotient`) * `hysteresisUpwardMultiplier`
+
 The `hysteresisQuotient` must be determined first, as it affects both upward and downward thresholds.
  
 ### Downward Hysteresis
@@ -77,7 +77,7 @@ This BRIP modifies network constants only and maintains full backward compatibil
  
 ## Security Considerations
  
-Reducing the hysteresis buffer narrows the margin of safety against balance oscillation. If the upward and downward thresholds are set too close together, validators near an increment boundary could experience rapid effective balance toggling, which increases state churn and computational overhead during epoch processing. The chosen values should be validated through simulation against realistic validator balance distributions before deployment.
+Reducing the hysteresis buffer narrows the margin of safety against balance oscillation. If the upward and downward thresholds are set too close together, validators near an increment boundary could experience rapid effective balance toggling, which increases state churn and computational overhead during epoch processing. This is unlikely however to be a significant situation as Berachain doesn't enforce slashing and penalties, so validator balances can only decrease via explicit withdrawals.
  
 ## Copyright
  

--- a/meta/BRIP-0008.md
+++ b/meta/BRIP-0008.md
@@ -1,0 +1,84 @@
+---
+brip: 0008
+title: Validator Effective Balance Hysteresis Constant Update
+author: P-OPS Team
+status: Draft
+created: 2026-03-30
+type: Core
+---
+ 
+## Summary
+ 
+This proposal updates the `hysteresisQuotient`, `hysteresisUpwardMultiplier`, `hysteresisDownwardMultiplier`, and `effectiveBalanceIncrement` constants to stabilize validator effective balances, improve capital efficiency, and prevent unexpected validator ejections unrelated to consensus faults.
+ 
+## Motivation
+ 
+The current validator effective balance hysteresis configuration creates economic friction and reduces capital efficiency, particularly regarding upward thresholds.
+ 
+Effective balances currently use 10,000 BERA increments. Validators must exceed the next increment level by an additional 12,500 BERA to trigger a balance increase — meaning actual requirements equal 125% of the increment size. For example, moving from 250,000 to 260,000 BERA effective balance requires holding over 262,500 BERA actual balance. This inefficiency prevents staked capital from being recognized quickly.
+ 
+The 12,500 BERA buffer strands capital unnecessarily and creates confusion in the system. With a 310,000 BERA stake, a validator's effective balance could range between 308,000 and 322,500 BERA due to hysteresis mechanisms, making economic behavior difficult to predict.
+ 
+This BRIP aims to improve validator set capital efficiency by reducing the upward buffer requirement, tightening the downward sensitivity, and opening discussion on whether the base increment should change from 10,000 BERA.
+ 
+## Specification
+ 
+### Proposed Constant Updates
+ 
+The following mainnet constants are proposed for update:
+ 
+| Constant | Current Value | Proposed Value | Description |
+|---|---|---|---|
+| `effectiveBalanceIncrement` | 10,000 | TBD | Base unit for effective balance changes; optimal granularity under discussion |
+| `hysteresisQuotient` | 4 | TBD | Determines downward sensitivity and upward threshold base |
+| `hysteresisUpwardMultiplier` | 5 | TBD | Set with quotient to achieve target upward threshold percentage |
+| `hysteresisDownwardMultiplier` | 1 | TBD | Set with quotient to achieve target downward threshold percentage |
+ 
+These constants are defined in the [mainnet.go](https://github.com/berachain/beacon-kit/tree/v1.3.0/config/spec/mainnet.go#L116) and [state_processor.go](https://github.com/berachain/beacon-kit/tree/v1.3.0/state-transition/core/state_processor.go#L386) files within the beacon-kit repository.
+ 
+### Hysteresis Threshold Formulas
+ 
+The upward and downward thresholds are derived from the constants as follows:
+ 
+- **Downward threshold** = `effectiveBalanceIncrement` - (`effectiveBalanceIncrement` * `hysteresisDownwardMultiplier` / `hysteresisQuotient`)
+- **Upward threshold** = `effectiveBalanceIncrement` + (`effectiveBalanceIncrement` * `hysteresisUpwardMultiplier` / `hysteresisQuotient`)
+ 
+The `hysteresisQuotient` must be determined first, as it affects both upward and downward thresholds.
+ 
+### Downward Hysteresis
+ 
+The suggested downward threshold targets approximately -100 BERA to prevent minor balance fluctuations from triggering effective balance changes. One possible parameter set:
+ 
+- `hysteresisQuotient` = 10,000
+- `hysteresisDownwardMultiplier` = 100
+ 
+### Upward Hysteresis
+ 
+The suggested upward threshold reduces the required buffer to approximately 10% of the `effectiveBalanceIncrement` (currently 1,000 BERA) for quicker capital recognition. One possible parameter set:
+ 
+- `hysteresisQuotient` = 100
+- `hysteresisUpwardMultiplier` = 10
+ 
+### Effective Balance Increment
+ 
+The `effectiveBalanceIncrement` serves as the base unit for all effective balance changes. Smaller increments allow rewards to be recognized more frequently but may increase processing overhead. The current value of 10,000 BERA provides reasonable granularity across approximately 975 validator slots. The optimal value remains under community discussion.
+ 
+## Rationale
+ 
+Mathematical dependencies require determining the `hysteresisQuotient` first, as it affects both upward and downward thresholds. The `hysteresisUpwardMultiplier` is then selected to achieve the desired upward buffer percentage.
+ 
+The current 125% upward threshold (requiring 12,500 BERA overshoot per 10,000 BERA increment) creates an excessively large dead zone of unrecognized capital. Reducing this to approximately 110% strikes a balance between capital efficiency and protection against balance oscillation. Community discussion has identified an optimal threshold range between 100 and 1,000 BERA for the upward buffer.
+ 
+A tighter downward threshold (approximately -100 BERA instead of the current -2,500 BERA) provides better protection against unexpected effective balance drops caused by minor fluctuations, reducing the risk of validator ejection events unrelated to consensus faults.
+ 
+## Backward Compatibility
+ 
+This BRIP modifies network constants only and maintains full backward compatibility with the current Berachain protocol implementation. A network upgrade is required to apply the new constant values. No changes to validator software, staking mechanics, or client APIs are introduced.
+ 
+## Security Considerations
+ 
+Reducing the hysteresis buffer narrows the margin of safety against balance oscillation. If the upward and downward thresholds are set too close together, validators near an increment boundary could experience rapid effective balance toggling, which increases state churn and computational overhead during epoch processing. The chosen values should be validated through simulation against realistic validator balance distributions before deployment.
+ 
+## Copyright
+ 
+All copyrights and related rights in this work are waived under CCO 1.0 Universal.

--- a/meta/BRIP-0008.md
+++ b/meta/BRIP-0008.md
@@ -29,10 +29,10 @@ The following mainnet constants are proposed for update:
  
 | Constant | Current Value | Proposed Value | Description |
 |---|---|---|---|
-| `effectiveBalanceIncrement` | 10,000 | TBD | Base unit for effective balance changes; optimal granularity under discussion |
-| `hysteresisQuotient` | 4 | TBD | Determines downward sensitivity and upward threshold base |
-| `hysteresisUpwardMultiplier` | 5 | TBD | Set with quotient to achieve target upward threshold percentage |
-| `hysteresisDownwardMultiplier` | 1 | TBD | Set with quotient to achieve target downward threshold percentage |
+| `effectiveBalanceIncrement` | 10,000 | 10,000 | Base unit for effective balance changes; optimal granularity under discussion |
+| `hysteresisQuotient` | 4 | 100 | Determines downward sensitivity and upward threshold base |
+| `hysteresisUpwardMultiplier` | 5 | 10 | Set with quotient to achieve target upward threshold percentage |
+| `hysteresisDownwardMultiplier` | 1 | 1 | Set with quotient to achieve target downward threshold percentage |
  
 These constants are defined in the [mainnet.go](https://github.com/berachain/beacon-kit/tree/v1.3.0/config/spec/mainnet.go#L116) and [state_processor.go](https://github.com/berachain/beacon-kit/tree/v1.3.0/state-transition/core/state_processor.go#L386) files within the beacon-kit repository.
  
@@ -49,8 +49,8 @@ The `hysteresisQuotient` must be determined first, as it affects both upward and
  
 The suggested downward threshold targets approximately -100 BERA to prevent minor balance fluctuations from triggering effective balance changes. One possible parameter set:
  
-- `hysteresisQuotient` = 10,000
-- `hysteresisDownwardMultiplier` = 100
+- `hysteresisQuotient` = 100
+- `hysteresisDownwardMultiplier` = 1
  
 ### Upward Hysteresis
  

--- a/meta/BRIP-0009.md
+++ b/meta/BRIP-0009.md
@@ -2,7 +2,7 @@
 brip: 0009
 title: Deprecation of Go-ethereum Execution Client
 author: calbera, fridrik01, grizzlybera
-status: Draft
+status: Final
 created: 2026-01-11
 type: Core
 requires: BRIP-0001, BRIP-0004

--- a/meta/BRIP-0010.md
+++ b/meta/BRIP-0010.md
@@ -2,7 +2,7 @@
 brip: 0010
 title: Fusaka Hardfork Specification
 author: calbera, fridrik01
-status: Draft
+status: Review
 created: 2026-03-30
 type: Core
 requires: BRIP-0001, BRIP-0008

--- a/meta/BRIP-0010.md
+++ b/meta/BRIP-0010.md
@@ -126,7 +126,7 @@ Any RLP-encoded block exceeding **10 MiB** is considered invalid. With a 2 MiB s
  
 Individual transactions are capped at **2^24 (16,777,216) gas**, approximately half a typical block gas limit. Transactions exceeding this limit are rejected during pool validation and block verification.
  
-These caps are adopted as **upper-bound safety measures**. Given Berachain's current 30M gas limit and 2-second block times, blocks and transactions are well within these limits under normal operation. The caps provide defense-in-depth against adversarial oversized blocks that could impair propagation within Berachain's tight slot times, without restricting any current legitimate use case.
+These caps are adopted as **upper-bound safety measures**. Given Berachain's current 36M gas limit and 2-second block times, blocks and transactions are well within these limits under normal operation. The caps provide defense-in-depth against adversarial oversized blocks that could impair propagation within Berachain's tight slot times, without restricting any current legitimate use case.
  
 ### 7. Validator Effective Balance Hysteresis Update (BRIP-0008)
  

--- a/meta/BRIP-0010.md
+++ b/meta/BRIP-0010.md
@@ -1,0 +1,271 @@
+---
+brip: 0010
+title: Fusaka Hardfork Specification
+author: calbera, fridrik01
+status: Draft
+created: 2026-03-30
+type: Core
+requires: BRIP-0001, BRIP-0008
+---
+ 
+## Summary
+ 
+This BRIP defines the scope and specification for the Fulu hardfork on Berachain. The upgrade bundles consensus layer improvements, execution layer EIP adoptions from Ethereum's Fusaka and Glamsterdam forks, and parameter updates for the next iteration of Proof of Liquidity. Specifically, the hardfork includes: EIP-6110 style deposit processing, EIP-7951 (P-256 precompile), a contract code size limit increase, EIP-7939 (CLZ opcode), EIP-7823/7883 (MODEXP repricing), EIP-7934/7825 (block and transaction size caps), validator effective balance hysteresis updates (BRIP-0008), and consensus layer parameter changes to support the next iteration of PoL.
+ 
+## Motivation
+ 
+Berachain's Fulu hardfork addresses several categories of improvements:
+ 
+1. **Deposit processing reliability**: The current deposit mechanism relies on an eth1 follow distance and delayed queue, which introduces latency and complexity. Migrating to EIP-6110 style in-payload deposit processing eliminates this indirection.
+ 
+2. **EVM feature parity**: Adopting select Fusaka and Glamsterdam EIPs ensures Berachain remains compatible with emerging Ethereum tooling, wallet standards (passkeys/WebAuthn), and security best practices.
+ 
+3. **DoS hardening**: MODEXP repricing, block size caps, and transaction gas caps close known underpricing vectors before they can be exploited.
+ 
+4. **Validator economics**: The current hysteresis configuration strands validator capital unnecessarily. Updating these constants improves capital efficiency across the validator set.
+ 
+5. **PoL evolution**: Consensus layer parameter changes are required to support the next iteration of Proof of Liquidity.
+ 
+## Specification
+ 
+### 1. EIP-6110: In-Payload Deposit Processing
+ 
+Berachain adopts EIP-6110 style deposit processing with the following adaptations for its architecture:
+ 
+#### Consensus Layer Changes
+ 
+- Deposit requests are included directly in execution payloads rather than being fetched via the eth1 data voting mechanism. Post-Fulu, there is no eth1 follow distance for deposits.
+- Deposits are processed **per-block** (not per-epoch as on Ethereum mainnet), consistent with Berachain's single-slot finality model.
+- A one-time **fork-boundary catchup** mechanism runs on the first Fulu block: the CL fetches deposits from the previous EL block to ensure no deposits are lost during the transition.
+- `MaxDepositsPerBlock` is set to **8192** as a safety cap. With a minimum of ~45,000 gas per deposit and a 30M gas block limit, this cap is unreachable in practice.
+ 
+#### Execution Layer Changes
+ 
+- The EL emits a **custom deposit event**: `Deposit(bytes,bytes,uint64,bytes,uint64)` with topic `0x68af751683498a9f9be59fe8b0d52a64dd155255d85cdb29fea30b1e3f891d46`. This differs from Ethereum's standard `DepositEvent` by using native `uint64` types for the amount and index fields instead of `bytes`.
+- The EL deposit parser performs **little-endian conversion** when constructing the 192-byte deposit request bytestring (48B pubkey + 32B credentials + 8B amount + 96B signature + 8B index), maintaining wire-format compatibility with the CL.
+ 
+#### Differences from Ethereum Mainnet EIP-6110
+ 
+| Aspect | Ethereum Mainnet | Berachain |
+|---|---|---|
+| Deposit event signature | `DepositEvent(bytes,bytes,bytes,bytes,bytes)` | `Deposit(bytes,bytes,uint64,bytes,uint64)` |
+| Amount/Index encoding | `bytes` (little-endian padded) | Native `uint64` (converted at parse time) |
+| Processing cadence | Per-epoch | Per-block |
+| Eth1 follow distance post-fork | Removed | Removed |
+| Fork-boundary handling | Standard | One-time catchup from previous block |
+ 
+### 2. EIP-7951: secp256r1 (P-256) Precompile
+ 
+A new precompiled contract at address `0x100` (`P256VERIFY`) for ECDSA signature verification on the secp256r1 curve.
+ 
+- **Gas cost**: 6,900
+- **Input**: 160 bytes (32B message hash + 32B r + 32B s + 32B public key x + 32B public key y)
+- **Output**: 32 bytes (`0x01` for valid signature, empty for invalid)
+ 
+This enables native support for signatures from Apple Secure Enclave, Android Keystore, FIDO2/WebAuthn authenticators, and HSMs. EIP-7951 supersedes the earlier RIP-7212 with fixes for point-at-infinity validation and modular comparison vulnerabilities.
+ 
+### 3. Contract Code Size Limit Increase
+ 
+Berachain increases the contract code size limit using a **simple limit bump** approach:
+ 
+| Parameter | Current Value | Fulu Value |
+|---|---|---|
+| `MAX_CODE_SIZE` | 24,576 bytes (24 KB) | 32,768 bytes (32 KB) |
+| `MAX_INITCODE_SIZE` | 49,152 bytes (48 KB) | 65,536 bytes (64 KB) |
+ 
+#### Implementation Approach
+ 
+Rather than adopting the full EIP-7907 (which introduces gas metering for oversized code, cold/warm code state tracking, and a `codesize` field in account tuples), Berachain adopts a simpler approach aligned with EIP-7954: a straightforward increase of the size limits with no additional gas metering or account schema changes.
+ 
+This is implemented by overriding `limit_contract_code_size` in the EVM configuration environment -- a minimal change with low implementation risk.
+ 
+#### Trade-offs
+ 
+- **Pro**: Minimal implementation effort (configuration change only). No database schema migration, no new gas metering logic, no cold/warm code tracking complexity.
+- **Pro**: No risk of introducing gas calculation bugs in CALL/STATICCALL/DELEGATECALL/EXTCODESIZE paths.
+- **Con**: Contracts between 24-32 KB do not incur additional gas for code loading, meaning the cost of accessing large contracts is not reflected in gas. For Berachain's validator set size and network topology, this is an acceptable trade-off.
+- **Con**: No `codesize` field in account tuples, so `EXTCODESIZE` still requires loading full bytecode. This is a minor inefficiency for the small number of contracts near the size limit.
+ 
+#### Divergence from Ethereum Mainnet
+ 
+Ethereum mainnet plans to adopt EIP-7907 (with full gas metering and account schema changes) in a future Glamsterdam hardfork. Berachain's simpler approach diverges from this path. If EIP-7907 is eventually finalized and adopted by Ethereum, Berachain may adopt the full specification in a subsequent hardfork. The 32 KB limit chosen here is a conservative step that unlocks the most common use cases (complex DeFi protocols, large proxy patterns) without the architectural cost of the full EIP-7907 implementation.
+ 
+### 4. EIP-7939: CLZ (Count Leading Zeros) Opcode
+ 
+A new opcode `CLZ` (`0x1e`) that counts the number of leading zero bits in a 256-bit word.
+ 
+- **Gas cost**: 5 (matching `MUL`)
+- **Stack**: Pops 1 value, pushes 1 value. Returns 256 if input is zero.
+ 
+Replaces Solidity workarounds costing 184+ gas and 110-160 bytes of bytecode with a single 1-byte, 5-gas opcode. Benefits DeFi protocols using fixed-point math, logarithms, AMM curves, and bitmap-based data structures.
+ 
+### 5. EIP-7823 & EIP-7883: MODEXP Input Bounds and Gas Repricing
+ 
+#### EIP-7823: MODEXP Input Bounds
+ 
+Caps each MODEXP precompile input field (base, exponent, modulus) at **8,192 bits (1,024 bytes)**. Calls exceeding this limit consume all gas and return an error. Historical analysis shows no real-world MODEXP call has exceeded 513 bytes, so this cap is generous while reducing the testing surface.
+ 
+#### EIP-7883: MODEXP Gas Cost Increase
+ 
+Reprices MODEXP to match actual computational cost:
+ 
+- Minimum gas raised from **200 to 500** (2.5x)
+- General operation cost approximately **tripled** (division-by-3 factor removed)
+- Exponent penalty for inputs exceeding 32 bytes **doubled** (multiplier from 8 to 16)
+- Minimum base/modulus length assumed at **32 bytes** with baseline complexity of 16
+ 
+Approximately 99.7% of historical MODEXP calls see a 150-200% gas increase. This repricing is a prerequisite for safe gas limit increases and prevents MODEXP from becoming a DoS vector.
+ 
+### 6. EIP-7934 & EIP-7825: Block and Transaction Size Caps
+ 
+#### EIP-7934: Block Size Cap
+ 
+Any RLP-encoded block exceeding **10 MiB** is considered invalid. With a 2 MiB safety margin for consensus overhead, the effective execution payload cap is **8 MiB**.
+ 
+#### EIP-7825: Transaction Gas Cap
+ 
+Individual transactions are capped at **2^24 (16,777,216) gas**, approximately half a typical block gas limit. Transactions exceeding this limit are rejected during pool validation and block verification.
+ 
+These caps are adopted as **upper-bound safety measures**. Given Berachain's current 30M gas limit and 2-second block times, blocks and transactions are well within these limits under normal operation. The caps provide defense-in-depth against adversarial oversized blocks that could impair propagation within Berachain's tight slot times, without restricting any current legitimate use case.
+ 
+### 7. Validator Effective Balance Hysteresis Update (BRIP-0008)
+ 
+The following hysteresis constants are updated to improve validator capital efficiency:
+ 
+| Constant | Current Value | Fulu Value | Effect |
+|---|---|---|---|
+| `effectiveBalanceIncrement` | 10,000 | 10,000 | Unchanged -- maintains current granularity |
+| `hysteresisQuotient` | 4 | 100 | Enables finer-grained threshold control |
+| `hysteresisDownwardMultiplier` | 1 | 1 | Downward buffer: -100 BERA (was -2,500) |
+| `hysteresisUpwardMultiplier` | 5 | 10 | Upward buffer: +1,000 BERA / ~110% (was +12,500 / 125%) |
+ 
+**Resulting thresholds:**
+ 
+- **Downward**: A validator's actual balance must fall **100 BERA** below an increment boundary to trigger an effective balance decrease (previously 2,500 BERA). This prevents unexpected effective balance drops from minor fluctuations.
+- **Upward**: A validator must exceed the next increment boundary by **1,000 BERA** (~10% of the increment) to trigger an effective balance increase (previously 12,500 BERA / 125%). This allows staked capital to be recognized significantly faster.
+ 
+For example, increasing effective balance from 250,000 to 260,000 BERA now requires an actual balance of 261,000 BERA (previously 262,500 BERA).
+ 
+See BRIP-0008 for full motivation and analysis.
+ 
+### 8. Proof of Liquidity: Consensus Layer Parameter Updates
+ 
+The Fulu fork introduces new values for the EVM inflation parameters in the consensus layer chain specification to support the next iteration of Proof of Liquidity:
+ 
+- `EVMInflationAddressFulu` -- Updated inflation recipient address
+- `EVMInflationPerBlockFulu` -- Updated per-block inflation amount
+ 
+These parameters follow the same pattern as the Genesis-to-Deneb1 migration and control the per-block minting of native BERA to the PoL system contract. The specific values will be finalized as part of the PoL vNext design process and updated in this specification prior to the fork.
+ 
+## Rationale
+ 
+### Fork bundling strategy
+ 
+Bundling these changes into a single hardfork minimizes the operational burden on validators (one upgrade cycle instead of many) while ensuring interdependent changes (e.g., EIP-6110 deposit processing and PoL parameter updates) activate atomically.
+ 
+### EIP selection criteria
+ 
+EIPs were evaluated on three axes:
+1. **Security**: MODEXP repricing and size caps close known DoS vectors
+2. **Ecosystem compatibility**: P-256 precompile and CLZ opcode keep Berachain aligned with Ethereum tooling and emerging wallet standards
+3. **Berachain relevance**: EIP-7918 (blob base fee) was excluded as Berachain does not use blob transactions
+ 
+### Contract size approach
+ 
+The simple limit bump was chosen over full EIP-7907 because:
+- EIP-7907 was removed from Ethereum's Fusaka fork and lacks a finalized specification
+- The account schema migration required by EIP-7907 carries significant implementation risk for minimal benefit at the 32 KB level
+- A future hardfork can adopt the full EIP-7907 specification if and when it is finalized on Ethereum mainnet
+ 
+## Backward Compatibility
+ 
+- **EIP-6110**: Requires coordinated CL and EL upgrades. Pre-fork deposit processing continues until the fork block, at which point the catchup mechanism ensures continuity.
+- **Contract size limit**: Contracts deployed before the fork are unaffected. Only new deployments can use the expanded 32 KB limit.
+- **MODEXP repricing**: Existing contracts calling MODEXP will see higher gas costs. Historical analysis indicates negligible real-world impact.
+- **Block/transaction size caps**: No existing blocks or transactions on Berachain exceed these limits.
+- **Hysteresis update**: Validator effective balances will be recalculated at the fork boundary using the new thresholds. Some validators may see immediate effective balance increases.
+- **PoL parameters**: The inflation address and amount change atomically at the fork block.
+ 
+All changes require a coordinated network upgrade across both CL (beacon-kit) and EL (bera-reth) clients.
+ 
+## Implementation Plan
+ 
+### 1. EIP-6110: In-Payload Deposit Processing
+ 
+**CL (beacon-kit):** PR [beacon-kit#2794](https://github.com/berachain/beacon-kit/pull/2794) introduces the Fulu fork plumbing, new `beacon/deposits/` package, per-block deposit validation in `state-transition/core/`, and the fork-boundary catchup mechanism. This PR is up and under review.
+ 
+**EL (bera-reth):** PR [bera-reth#226](https://github.com/berachain/bera-reth/pull/226) adds the custom deposit event parser (`src/deposits.rs`), wires it into the block executor for Prague-active blocks, and updates the chain spec with Berachain's deposit event topic. This PR is up and under review.
+ 
+Both PRs must be merged and released together for the fork to activate correctly.
+ 
+### 2. EIP-7951: secp256r1 (P-256) Precompile
+ 
+**EL (bera-reth):** EIP-7951 is implemented in **revm** (the underlying Rust EVM library). Upstream reth already includes this as part of Fusaka support. A bera-reth PR is needed to rebase onto the upstream reth version that includes the Fusaka revm dependency (or cherry-pick the revm bump), and to enable the P-256 precompile in bera-reth's hardfork configuration for the Fulu fork.
+ 
+No CL changes are required.
+ 
+### 3. Contract Code Size Limit Increase
+ 
+**EL (bera-reth):** A single PR to bera-reth overriding `limit_contract_code_size` and `limit_initcode_size` in the `CfgEnv` to the new values (32 KB / 64 KB), gated behind the Fulu hardfork activation block. This is a minimal configuration change -- no revm fork or upstream dependency required.
+ 
+No CL changes are required.
+ 
+### 4. EIP-7939: CLZ (Count Leading Zeros) Opcode
+ 
+**EL (bera-reth):** EIP-7939 is implemented in **revm** as part of the Fusaka opcode set. Same as EIP-7951 -- a bera-reth PR to pull in the upstream revm version with CLZ support and enable it in the Fulu hardfork configuration.
+ 
+No CL changes are required.
+ 
+### 5. EIP-7823 & EIP-7883: MODEXP Input Bounds and Gas Repricing
+ 
+**EL (bera-reth):** Both EIPs are implemented in **revm**'s precompile layer as part of Fusaka. A bera-reth PR to pull in the upstream revm version with the MODEXP changes and enable them in the Fulu hardfork configuration. Same revm bump as EIP-7951 and EIP-7939 -- these can all land in a single bera-reth PR that upgrades the revm dependency and configures the Fulu fork.
+ 
+No CL changes are required.
+ 
+### 6. EIP-7934 & EIP-7825: Block and Transaction Size Caps
+ 
+**EL (bera-reth):** A PR to bera-reth adding validation checks in two places:
+- **Block validation**: Reject RLP-encoded blocks exceeding 10 MiB during both block import and block building.
+- **Transaction pool validation**: Reject transactions with gas limits exceeding 2^24 during pool ingress and block verification.
+ 
+These are straightforward validation guard checks in the block executor and transaction pool modules, gated behind the Fulu hardfork activation. If upstream reth already implements these for Fusaka, the bera-reth PR may simply enable the existing checks.
+ 
+No CL changes are required.
+ 
+### 7. Validator Effective Balance Hysteresis Update (BRIP-0008)
+ 
+**CL (beacon-kit):** A PR to beacon-kit updating the hysteresis constants in `config/spec/mainnet.go` (and corresponding testnet/devnet configs) with the new Fulu values: `HysteresisQuotient = 100`, `HysteresisUpwardMultiplier = 10`, `HysteresisDownwardMultiplier = 1`. The values are gated behind the Fulu fork epoch.
+ 
+No EL changes are required.
+ 
+### 8. Proof of Liquidity: Consensus Layer Parameter Updates
+ 
+**CL (beacon-kit):** A PR to beacon-kit adding new `EVMInflationAddressFulu` and `EVMInflationPerBlockFulu` values in `config/spec/mainnet.go`, following the same pattern as the existing Genesis and Deneb1 parameter pairs. The specific values will be set once the PoL vNext design is finalized.
+ 
+No EL changes are required.
+ 
+### Summary
+ 
+| Change | beacon-kit (CL) | bera-reth (EL) |
+|---|---|---|
+| EIP-6110 | PR [#2794](https://github.com/berachain/beacon-kit/pull/2794) (up) | PR [#226](https://github.com/berachain/bera-reth/pull/226) (up) |
+| EIP-7951 (P-256) | -- | PR: revm bump + Fulu config |
+| Code size limit | -- | PR: `CfgEnv` override |
+| EIP-7939 (CLZ) | -- | PR: revm bump + Fulu config |
+| EIP-7823/7883 (MODEXP) | -- | PR: revm bump + Fulu config |
+| EIP-7934/7825 (size caps) | -- | PR: validation checks |
+| BRIP-0008 (hysteresis) | PR: `mainnet.go` constants | -- |
+| PoL vNext | PR: `mainnet.go` inflation params | -- |
+ 
+EIP-7951, EIP-7939, and EIP-7823/7883 all depend on the same upstream revm version bump and can be delivered in a **single bera-reth PR** that upgrades the revm dependency and enables the Fusaka EVM features under the Fulu hardfork gate. The contract code size limit override and block/transaction size caps can be included in the same PR or split out for review clarity.
+ 
+## Security Considerations
+ 
+- **EIP-6110 fork boundary**: The one-time catchup mechanism must be tested thoroughly to prevent deposit loss or double-processing during the transition.
+- **Contract size limit without gas metering**: Contracts between 24-32 KB do not pay additional gas for code loading. This is acceptable given Berachain's validator set but should be monitored. If large-contract access becomes a performance concern, full EIP-7907 gas metering can be adopted in a subsequent fork.
+- **Hysteresis tightening**: The reduced downward buffer (-100 BERA vs -2,500 BERA) means validators closer to increment boundaries are more sensitive to balance changes. This should be validated through simulation against realistic balance distributions.
+- **MODEXP repricing**: While the gas increase is significant, historical usage patterns on Berachain should be analyzed to confirm no critical protocols are adversely affected.
+ 
+## Copyright
+ 
+All copyrights and related rights in this work are waived under CCO 1.0 Universal.

--- a/meta/BRIP-0010.md
+++ b/meta/BRIP-0010.md
@@ -10,11 +10,11 @@ requires: BRIP-0001, BRIP-0008
  
 ## Summary
  
-This BRIP defines the scope and specification for the Fulu hardfork on Berachain. The upgrade bundles consensus layer improvements, execution layer EIP adoptions from Ethereum's Fusaka and Glamsterdam forks, and parameter updates for the next iteration of Proof of Liquidity. Specifically, the hardfork includes: EIP-6110 style deposit processing, EIP-7951 (P-256 precompile), a contract code size limit increase, EIP-7939 (CLZ opcode), EIP-7823/7883 (MODEXP repricing), EIP-7934/7825 (block and transaction size caps), validator effective balance hysteresis updates (BRIP-0008), and consensus layer parameter changes to support the next iteration of PoL.
+This BRIP defines the scope and specification for the Fusaka hardfork on Berachain. The upgrade bundles consensus layer improvements, execution layer EIP adoptions from Ethereum's Fusaka and Glamsterdam forks, and parameter updates for the next iteration of Proof of Liquidity. Specifically, the hardfork includes: EIP-6110 style deposit processing, EIP-7951 (P-256 precompile), a contract code size limit increase, EIP-7939 (CLZ opcode), EIP-7823/7883 (MODEXP repricing), EIP-7934/7825 (block and transaction size caps), validator effective balance hysteresis updates (BRIP-0008), and consensus layer parameter changes to support the next iteration of PoL.
  
 ## Motivation
  
-Berachain's Fulu hardfork addresses several categories of improvements:
+Berachain's Fusaka hardfork addresses several categories of improvements:
  
 1. **Deposit processing reliability**: The current deposit mechanism relies on an eth1 follow distance and delayed queue, which introduces latency and complexity. Migrating to EIP-6110 style in-payload deposit processing eliminates this indirection.
  
@@ -68,7 +68,7 @@ This enables native support for signatures from Apple Secure Enclave, Android Ke
  
 Berachain increases the contract code size limit using a **simple limit bump** approach:
  
-| Parameter | Current Value | Fulu Value |
+| Parameter | Current Value | Osaka Value |
 |---|---|---|
 | `MAX_CODE_SIZE` | 24,576 bytes (24 KB) | 32,768 bytes (32 KB) |
 | `MAX_INITCODE_SIZE` | 49,152 bytes (48 KB) | 65,536 bytes (64 KB) |
@@ -200,25 +200,25 @@ Both PRs must be merged and released together for the fork to activate correctly
  
 ### 2. EIP-7951: secp256r1 (P-256) Precompile
  
-**EL (bera-reth):** EIP-7951 is implemented in **revm** (the underlying Rust EVM library). Upstream reth already includes this as part of Fusaka support. A bera-reth PR is needed to rebase onto the upstream reth version that includes the Fusaka revm dependency (or cherry-pick the revm bump), and to enable the P-256 precompile in bera-reth's hardfork configuration for the Fulu fork.
+**EL (bera-reth):** EIP-7951 is implemented in **revm** (the underlying Rust EVM library). Upstream reth already includes this as part of Osaka support. A bera-reth PR is needed to rebase onto the upstream reth version that includes the Fusaka revm dependency (or cherry-pick the revm bump), and to enable the P-256 precompile in bera-reth's hardfork configuration for the Osaka fork.
  
 No CL changes are required.
  
 ### 3. Contract Code Size Limit Increase
  
-**EL (bera-reth):** A single PR to bera-reth overriding `limit_contract_code_size` and `limit_initcode_size` in the `CfgEnv` to the new values (32 KB / 64 KB), gated behind the Fulu hardfork activation block. This is a minimal configuration change -- no revm fork or upstream dependency required.
+**EL (bera-reth):** A single PR to bera-reth overriding `limit_contract_code_size` and `limit_initcode_size` in the `CfgEnv` to the new values (32 KB / 64 KB), gated behind the Osaka hardfork activation block. This is a minimal configuration change -- no revm fork or upstream dependency required.
  
 No CL changes are required.
  
 ### 4. EIP-7939: CLZ (Count Leading Zeros) Opcode
  
-**EL (bera-reth):** EIP-7939 is implemented in **revm** as part of the Fusaka opcode set. Same as EIP-7951 -- a bera-reth PR to pull in the upstream revm version with CLZ support and enable it in the Fulu hardfork configuration.
+**EL (bera-reth):** EIP-7939 is implemented in **revm** as part of the Fusaka opcode set. Same as EIP-7951 -- a bera-reth PR to pull in the upstream revm version with CLZ support and enable it in the Osaka hardfork configuration.
  
 No CL changes are required.
  
 ### 5. EIP-7823 & EIP-7883: MODEXP Input Bounds and Gas Repricing
  
-**EL (bera-reth):** Both EIPs are implemented in **revm**'s precompile layer as part of Fusaka. A bera-reth PR to pull in the upstream revm version with the MODEXP changes and enable them in the Fulu hardfork configuration. Same revm bump as EIP-7951 and EIP-7939 -- these can all land in a single bera-reth PR that upgrades the revm dependency and configures the Fulu fork.
+**EL (bera-reth):** Both EIPs are implemented in **revm**'s precompile layer as part of Fusaka. A bera-reth PR to pull in the upstream revm version with the MODEXP changes and enable them in the Osaka hardfork configuration. Same revm bump as EIP-7951 and EIP-7939 -- these can all land in a single bera-reth PR that upgrades the revm dependency and configures the Osaka fork.
  
 No CL changes are required.
  
@@ -228,7 +228,7 @@ No CL changes are required.
 - **Block validation**: Reject RLP-encoded blocks exceeding 10 MiB during both block import and block building.
 - **Transaction pool validation**: Reject transactions with gas limits exceeding 2^24 during pool ingress and block verification.
  
-These are straightforward validation guard checks in the block executor and transaction pool modules, gated behind the Fulu hardfork activation. If upstream reth already implements these for Fusaka, the bera-reth PR may simply enable the existing checks.
+These are straightforward validation guard checks in the block executor and transaction pool modules, gated behind the Osaka hardfork activation. If upstream reth already implements these for Fusaka, the bera-reth PR may simply enable the existing checks.
  
 No CL changes are required.
  
@@ -249,15 +249,15 @@ No EL changes are required.
 | Change | beacon-kit (CL) | bera-reth (EL) |
 |---|---|---|
 | EIP-6110 | PR [#2794](https://github.com/berachain/beacon-kit/pull/2794) (up) | PR [#226](https://github.com/berachain/bera-reth/pull/226) (up) |
-| EIP-7951 (P-256) | -- | PR: revm bump + Fulu config |
+| EIP-7951 (P-256) | -- | PR: revm bump + Osaka config |
 | Code size limit | -- | PR: `CfgEnv` override |
-| EIP-7939 (CLZ) | -- | PR: revm bump + Fulu config |
-| EIP-7823/7883 (MODEXP) | -- | PR: revm bump + Fulu config |
+| EIP-7939 (CLZ) | -- | PR: revm bump + Osaka config |
+| EIP-7823/7883 (MODEXP) | -- | PR: revm bump + Osaka config |
 | EIP-7934/7825 (size caps) | -- | PR: validation checks |
 | BRIP-0008 (hysteresis) | PR: `mainnet.go` constants | -- |
 | PoL vNext | PR: `mainnet.go` inflation params | -- |
  
-EIP-7951, EIP-7939, and EIP-7823/7883 all depend on the same upstream revm version bump and can be delivered in a **single bera-reth PR** that upgrades the revm dependency and enables the Fusaka EVM features under the Fulu hardfork gate. The contract code size limit override and block/transaction size caps can be included in the same PR or split out for review clarity.
+EIP-7951, EIP-7939, and EIP-7823/7883 all depend on the same upstream revm version bump and can be delivered in a **single bera-reth PR** that upgrades the revm dependency and enables the Osaka EVM features under the Osaka hardfork gate. The contract code size limit override and block/transaction size caps can be included in the same PR or split out for review clarity.
  
 ## Security Considerations
  

--- a/meta/BRIP-0010.md
+++ b/meta/BRIP-0010.md
@@ -37,7 +37,7 @@ Berachain adopts EIP-6110 style deposit processing with the following adaptation
 - Deposit requests are included directly in execution payloads rather than being fetched via the eth1 data voting mechanism. Post-Fulu, there is no eth1 follow distance for deposits.
 - Deposits are processed **per-block** (not per-epoch as on Ethereum mainnet), consistent with Berachain's single-slot finality model.
 - A one-time **fork-boundary catchup** mechanism runs on the first Fulu block: the CL fetches deposits from the previous EL block to ensure no deposits are lost during the transition.
-- `MaxDepositsPerBlock` is set to **8192** as a safety cap. With a minimum of ~45,000 gas per deposit and a 30M gas block limit, this cap is unreachable in practice.
+- `MaxDepositsPerBlock` was **16** pre-Fulu. During the fork-boundary catchup, the limit is effectively **uncapped** to drain all remaining pre-fork deposits. Post-Fulu, the limit becomes **8192**, matching the EIP-6110 `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD` — the maximum number of deposit requests that can fit in the execution requests payload. With a minimum of ~45,000 gas per deposit and a 30M gas block limit, this cap is unreachable in practice.
  
 #### Execution Layer Changes
  


### PR DESCRIPTION
BRIP-8: CL Hysteresis Updates from https://forum.berachain.com/t/brip-0008-validator-effective-balance-hysteresis-constant-update/1505

BRIP-10: New Fusaka EIPs and other CL changes to include in the next Berachain mainnet hardfork