### PR TITLE
docs: replace README proposals table with link to meta/

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,4 @@ BRIP may cover:
 
 ## Index of Proposals
 
-| BRIP | Title | Author | Status |
-|-----|-------|--------|--------|
-| [BRIP-0000](meta/BRIP-0000.md) | Process and Guidelines | aBear | Final |
-| [BRIP-0001](meta/BRIP-0001.md) | Execution Layer Forked Clients | calbera, rezbera | Review |
-| [BRIP-0002](meta/BRIP-0002.md) | Gas Fee Modifications | rezbera | Draft |
+Proposal documents are listed in [`meta/`](meta/).


### PR DESCRIPTION
Replaces the README proposal table with a single pointer to [`meta/`](https://github.com/berachain/BRIPs/tree/main/meta), so the README stays authoritative without duplicating rows that drift from each BRIP file.

Related: https://github.com/berachain/BRIPs/pull/21 updates the full table on `main` if you prefer to keep an enumerated index.