### PR TITLE
docs: refresh README proposal index (BRIP-0000–0010)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ BRIP may cover:
 
 | BRIP | Title | Author | Status |
 |-----|-------|--------|--------|
-| [BRIP-0000](meta/BRIP-0000.md) | Process and Guidelines | aBear | Final |
-| [BRIP-0001](meta/BRIP-0001.md) | Execution Layer Forked Clients | calbera, rezbera | Review |
-| [BRIP-0002](meta/BRIP-0002.md) | Gas Fee Modifications | rezbera | Draft |
+| [BRIP-0000](meta/BRIP-0000.md) | BRIP Process and Guidelines | aBear | Final |
+| [BRIP-0001](meta/BRIP-0001.md) | Execution Layer Forked Clients | calbera, rezbera | Final |
+| [BRIP-0002](meta/BRIP-0002.md) | Gas Fee Modifications | rezbera | Final |
+| [BRIP-0003](meta/BRIP-0003.md) | Stable Block Time | aBear, fridrik01 | Final |
+| [BRIP-0004](meta/BRIP-0004.md) | Enshrined Proof of Liquidity Reward Distribution | rezbera, calbera | Final |
+| [BRIP-0005](meta/BRIP-0005.md) | Default BGT Distribution Strategy for Validators | rezbera, calbera, aBear, fridrik01 | Draft |
+| [BRIP-0006](meta/BRIP-0006.md) | Baseline Cutting Board Automation | astro-bera, bar-bera, GrizzlyBera | Draft |
+| [BRIP-0007](meta/BRIP-0007.md) | Berachain Preconfirmations | rezbera, calbera, aBear, fridrik01, grizzlybera, tio | Review |
+| [BRIP-0008](meta/BRIP-0008.md) | Validator Effective Balance Hysteresis Constant Update | P-OPS Team | Accepted |
+| [BRIP-0009](meta/BRIP-0009.md) | Deprecation of Go-ethereum Execution Client | calbera, fridrik01, grizzlybera | Final |
+| [BRIP-0010](meta/BRIP-0010.md) | Fusaka Hardfork Specification | calbera, fridrik01 | Review |


### PR DESCRIPTION
Updates the README index to match current BRIP files under `meta/` (titles, authors, and statuses from each BRIP frontmatter through BRIP-0010).

